### PR TITLE
Revert entry point changes for carma exec

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,11 +20,9 @@
 # runs "roslaunch carma carma_docker.launch" after setting up the environment
 # such that ROS and CARMA are on the user's PATH
 
-if [ -z "$@" ] || [ "$@" = "bash" ]; then
+if [ -z "$@" ]; then
     # If no other command is passed to this script, run bash
-    source ~/.base-image/init-env.sh;
-    bash
+    source ~/.base-image/init-env.sh; exec "bash"
 else 
-    source ~/.base-image/init-env.sh;
-    bash -c "$@"
+    source ~/.base-image/init-env.sh; exec "$@"
 fi


### PR DESCRIPTION
Reverting the changes to the entrypoint after discovering it did not play nicely with all carma-configs. 

Electing instead to update the carma exec command to modify the entrypoint at runtime. 