### PR TITLE
carma-base-3.7.1 release

### DIFF
--- a/code_coverage/make_with_coverage.bash
+++ b/code_coverage/make_with_coverage.bash
@@ -29,6 +29,8 @@
 #
 #
 
+set -eo pipefail
+
 usage() { echo "Usage: make_with_coverage.bash -e <execution dir> -o <output dir> -m -t ";}
 
  
@@ -62,6 +64,10 @@ fi
 execution_dir=$(readlink -f ${execution_dir}) # Get execution directory as absolute path
 cd ${execution_dir} # cd to execution directory
 echo "Execution Dir: ${execution_dir}"
+
+if ! [ -d ${output_dir} ]; then
+	mkdir -p ${output_dir}
+fi
 
 output_dir=$(readlink -f ${output_dir}); # Get output directory as absolute path
 echo "Output Dir: ${output_dir}"

--- a/docs/PULL_REQUEST_TEMPLATE.md
+++ b/docs/PULL_REQUEST_TEMPLATE.md
@@ -39,6 +39,6 @@
 - [ ] My change requires a change to the documentation.
 - [ ] I have updated the documentation accordingly.
 - [ ] I have read the **CONTRIBUTING** document.
-[CARMA Contributing Guide](Contributing.md) 
+[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
 - [ ] I have added tests to cover my changes.
 - [ ] All new and existing tests passed.

--- a/docs/PULL_REQUEST_TEMPLATE.md
+++ b/docs/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,44 @@
+<!-- Thanks for the contribution, this is awesome. -->
+
+# PR Details
+## Description
+
+<!--- Describe your changes in detail -->
+
+## Related Issue
+
+<!--- This project only accepts pull requests related to open issues -->
+<!--- If suggesting a new feature or change, please discuss it in an issue first -->
+<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
+<!--- Please link to the issue here: -->
+
+## Motivation and Context
+
+<!--- Why is this change required? What problem does it solve? -->
+
+## How Has This Been Tested?
+
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to -->
+<!--- see how your change affects other areas of the code, etc. -->
+
+## Types of changes
+
+<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+
+- [ ] Defect fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that cause existing functionality to change)
+
+## Checklist:
+
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+
+- [ ] I have added any new packages to the sonar-scanner.properties file
+- [ ] My change requires a change to the documentation.
+- [ ] I have updated the documentation accordingly.
+- [ ] I have read the **CONTRIBUTING** document.
+[CARMA Contributing Guide](Contributing.md) 
+- [ ] I have added tests to cover my changes.
+- [ ] All new and existing tests passed.


### PR DESCRIPTION
Added changes to make_with_coverage.bash so that build and testing errors/failures are passed to circleci. Also added PR template. Related issue: [#369](https://github.com/usdot-fhwa-stol/carma-platform/issues/369)