### PR TITLE
Update build scripts to point to noetic/develop

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -167,7 +167,7 @@ RUN cd ~/ && \
 
 # Install VimbaSDK for the Mako cameras
 RUN cd ~/ && \
-        curl -L  https://github.com/usdot-fhwa-stol/avt_vimba_camera/raw/develop/Vimba_v3.1_Linux.tgz > Vimba_v3.1_Linux.tgz && \
+        curl -L  https://github.com/usdot-fhwa-stol/avt_vimba_camera/raw/noetic/develop/Vimba_v3.1_Linux.tgz > Vimba_v3.1_Linux.tgz && \
         sudo tar -xzf ./Vimba_v3.1_Linux.tgz -C /opt && \
         cd /opt/Vimba_3_1/VimbaGigETL && \
         sudo ./Install.sh && \

--- a/docker/build-image.sh
+++ b/docker/build-image.sh
@@ -43,7 +43,7 @@ while [[ $# -gt 0 ]]; do
             ;;
         -d|--develop)
             USERNAME=usdotfhwastoldev
-            COMPONENT_VERSION_STRING=develop
+            COMPONENT_VERSION_STRING=noetic/develop
             shift
             ;;
         -c|--candidate)


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This PR makes a small correction to the build-image script used in carma-base as well as the file used for the avt-vimba-driver downloaded in the image. The correction points things at noetic/develop instead of develop.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Local docker build testing
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
