### PR TITLE
Change carma user and group to 1001 in Docker container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ LABEL org.label-schema.build-date=${BUILD_DATE}
 ENV NVIDIA_VISIBLE_DEVICES ${NVIDIA_VISIBLE_DEVICES:-all}
 
 # Specify which driver libraries/binaries will be mounted inside the container
-ENV NVIDIA_DRIVER_CAPABILITIES ${NVIDIA_DRIVER_CAPABILITIES:+$NVIDIA_DRIVER_CAPABILITIES,}graphics
+ENV NVIDIA_DRIVER_CAPABILITIES ${NVIDIA_DRIVER_CAPABILITIES:+$NVIDIA_DRIVER_CAPABILITIES}
     
 # Avoid interactive prompts during the building of this docker image
 ARG DEBIAN_FRONTEND="noninteractive"

--- a/Dockerfile
+++ b/Dockerfile
@@ -101,8 +101,8 @@ RUN useradd -m $USERNAME && \
         mkdir -p /etc/sudoers.d && \
         echo "$USERNAME ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/$USERNAME && \
         chmod 0440 /etc/sudoers.d/$USERNAME && \
-        usermod  --uid 1000 $USERNAME && \
-        groupmod --gid 1000 $USERNAME
+        usermod  --uid 1001 $USERNAME && \
+        groupmod --gid 1001 $USERNAME
 
 RUN mkdir -p /opt/carma && chown carma:carma -R /opt/carma
 USER carma


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Changes the `carma` user and group IDs in the C1T version of the `carma-base` container image to `1001` so that it does not conflict with the `nvidia` used on Jetson platforms. Two alternative solutions would have been to change the `nvidia` user and group IDs or to use the `nvidia` user in place of the `carma` user on the Jetson. The first option is not ideal because it's unknown how that would affect the rest of the Jetson system. The second option is also not ideal because it would deviate from the conventional CARMA runtime configuration.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #86 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
When volumes owned by the `carma` group (`1001` on Jetson hosts) were passed into CARMA containers, the `carma` user inside the container (`1000`) was unable to access them because they did not technically belong to the same group (`1001` vs `1000`).

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
A Docker container image with the proposed modifications was built on a Jetson TX2, and volume access was successfully tested.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

**Note:** This is unlikely to be a breaking change unless user and group ID numbers are references instead of names. However, I did not see any references of this.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

**Note:** Documentation changes would be required only for C1T deployments as this only affects C1T.
