### PR TITLE
Add ros independant installation of catkin to carma-base to support ROS2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ ARG ROS_DISTRO=noetic
 RUN sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list' \ 
     && apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654 \ 
     && apt-get update \ 
-    && apt-get install 
+    && apt-get install \
         openssl \ 
         ca-certificates \
         ros-noetic-desktop-full \
@@ -246,6 +246,7 @@ RUN pip3 install future
 # install catkin_pkg
 RUN cd $HOME && \
         mkdir catkin_ros2_ws && \
+        cd catkin_ros2_ws && \
         git clone https://github.com/ros-infrastructure/catkin_pkg.git && \
         cd catkin_pkg && \
         # Checkout a known working commit

--- a/Dockerfile
+++ b/Dockerfile
@@ -241,6 +241,29 @@ RUN echo 'export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64' >> ~/.b
 # Install pip futures to support rosbridge
 RUN pip3 install future
 
+# Install non-ros1 dependant version of catkin
+# This can be used without issue for ROS2 builds wheras the noetic version has compatability issues
+# install catkin_pkg
+RUN cd $HOME && \
+        mkdir catkin_ros2_ws && \
+        git clone https://github.com/ros-infrastructure/catkin_pkg.git && \
+        cd catkin_pkg && \
+        # Checkout a known working commit
+        git checkout 60096f4b4a0975774651122b7e2d346545f8098a && \
+        python3 setup.py install --prefix $HOME/catkin --single-version-externally-managed --record foo --install-layout deb && \
+        cd ../ && \
+        # install catkin
+        git clone https://github.com/ros/catkin.git && \
+        cd catkin && \
+        # Checkout a known working commit
+        git checkout 085e8950cafa3eb979edff1646b9e3fe55a7053a && \
+        mkdir build && \
+        cd build && \
+        PYTHONPATH=$HOME/catkin/lib/python3/dist-packages/ cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/catkin -DPYTHON_EXECUTABLE=/usr/bin/python3 && \
+        make install
+        # Result is installation under ~/catkin so use with 
+        # source ~/cakin/setup.bash
+
 # Final system setup. This must go last before the ENTRYPOINT
 RUN mkdir -p /opt/carma/routes /opt/carma/logs /opt/carma/launch &&\
     echo "source ~/.base-image/init-env.sh" >> ~/.bashrc &&\

--- a/init-env.sh
+++ b/init-env.sh
@@ -20,6 +20,7 @@
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib/
 
 [ -f "/opt/ros/noetic/setup.bash" ] && source /opt/ros/noetic/setup.bash
+[ -f "/home/carma/catkin/setup.bash" ] && source /home/carma/catkin/setup.bash
 [ -f "/opt/autoware.ai/ros/install/setup.bash" ] && source /opt/autoware.ai/ros/install/setup.bash
 [ -f "/opt/carma/install/setup.bash" ] && source /opt/carma/install/setup.bash
 [ -f "/opt/carma/vehicle/config/carma.env" ] && source /opt/carma/vehicle/config/carma.env # Always source environment variables as last step


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Testing of ROS2 builds has shown that the version of catkin installed with ROS noetic is coupled with the system in some way and will throw an exception if called after foxy is sourced. To get around this and allow catkin packages to build in ROS2 catkin can be installed separately from source and then sourced itself before building ROS2 packages. 
This PR adds this installation under ~/catkin/ to keep it separate from ROS
<!--- Describe your changes in detail -->

## Related Issue
This is needed for the ROS 2 migration  https://github.com/usdot-fhwa-stol/carma-platform/milestone/4
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
To simplify the migration process allow packages to be built using catkin
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
This approach was tested for lanelet2_extension and hardcoded_params
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
