### PR TITLE
fix command line argument existance condition

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,7 +20,7 @@
 # runs "roslaunch carma carma_docker.launch" after setting up the environment
 # such that ROS and CARMA are on the user's PATH
 
-if [ -z "$@" ]; then
+if [ $# -eq 0 ]; then
     # If no other command is passed to this script, run bash
     source ~/.base-image/init-env.sh; exec "bash"
 else 


### PR DESCRIPTION
# PR Details
## Description

Fix for [this issue](https://github.com/usdot-fhwa-stol/carma-platform/issues/1829).

The `entrypoint.sh` script should check for _any_ command-line arguments. Current script throws `[: too many arguments` warning when more than one command-line argument is passed. 

More than one command-line argument is passed when the `command:` property in the `docker-compose.yml` script that creates this docker image is longer than one word. For example `command: bash -c 'wait-for-it.sh localhost:11311 -- roslaunch /opt/carma/vehicle/config/carma_docker.launch'` in `carma-config/carla_integration/docker-compose.yml`.

## Related Issue

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

This was tested by running the bash script with and without multiple command-line arguments. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
