### PR TITLE
make_with_coverage.bash: fix comparison

### DIFF
--- a/code_coverage/make_with_coverage.bash
+++ b/code_coverage/make_with_coverage.bash
@@ -56,7 +56,7 @@ do
 	esac
 done
 
-if [ "${do_make}" = false && "${do_test}" = false ]; then
+if [ "${do_make}" = false ] && [ "${do_test}" = false ]; then
   echo "Error -t or -m must be specified"
   exit 0
 fi


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Fixes comparison logic in make_with_coverage.bash

## Related Issue

Closes #132 

## Motivation and Context

Comparison logic is broken otherwise.

## How Has This Been Tested?

The Circle CI log no longer complains about this issue.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
