### PR TITLE
Dockerfile: install wait-for-it Ubuntu package instead of manually downloading and installing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -126,6 +126,7 @@ ARG ROS_DEPS="apt-transport-https \
         tmux \
         unzip \
         vim \
+        wait-for-it \
         x-window-system"
 
 RUN apt-get update && apt-get install -y lsb-release && apt-get clean ALL
@@ -203,9 +204,6 @@ RUN sudo echo 'export QT_X11_NO_MITSHM=1' >> /home/carma/.base-image/init-env.sh
 # Set Cyclone DDS as default RMW implementation
 RUN sudo echo 'export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp' >> /home/carma/.base-image/init-env.sh 
 
-RUN sudo git clone --depth 1 https://github.com/vishnubob/wait-for-it.git ~/.base-image/wait-for-it &&\
-    sudo mv ~/.base-image/wait-for-it/wait-for-it.sh /usr/bin 
-
 # Install Armadillo
 RUN cd ~/ && \
         curl -Lk  http://sourceforge.net/projects/arma/files/armadillo-9.800.1.tar.xz > armadillo-9.800.1.tar.xz && \
@@ -263,6 +261,9 @@ RUN cd $SONAR_DIR && \
         # Rename files 
         sudo mv $(ls $SONAR_DIR | grep "sonar-scanner-") $SONAR_DIR/sonar-scanner/ && \
         sudo mv $(ls $SONAR_DIR | grep "build-wrapper-") $SONAR_DIR/build-wrapper/ && \
+        # FIXME: The following symlink will no longer be required once images
+        # that depend on carma-base change from wait-for-it.sh to wait-for-it
+        sudo ln -s /usr/bin/wait-for-it /usr/bin/wait-for-it.sh && \
         # Add scanner, wrapper, and jq to PATH
         sudo echo 'export PATH=$PATH:/opt/jq/:$SONAR_DIR/sonar-scanner/bin/:$SONAR_DIR/build-wrapper/' >> /home/carma/.base-image/init-env.sh
 


### PR DESCRIPTION
# PR Details
## Description

Install wait-for-it Ubuntu package instead of git cloning and manually installing it

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

This gets rid of an unnecessary Docker layer

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
