### PR TITLE
Dockerfile: move export commands to init-env.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -198,12 +198,6 @@ RUN sudo rosdep init && \
         rosdep update && \
         rosdep install --from-paths ~/.base-image/workspace/src --ignore-src -y
 
-# Export QT X11 Forwarding variables
-RUN sudo echo 'export QT_X11_NO_MITSHM=1' >> /home/carma/.base-image/init-env.sh
-
-# Set Cyclone DDS as default RMW implementation
-RUN sudo echo 'export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp' >> /home/carma/.base-image/init-env.sh 
-
 # Install Armadillo
 RUN cd ~/ && \
         curl -Lk  http://sourceforge.net/projects/arma/files/armadillo-9.800.1.tar.xz > armadillo-9.800.1.tar.xz && \
@@ -228,8 +222,6 @@ RUN cd ~/ && \
         sudo tar -xzf ./Vimba_v5.0_Linux.tgz -C /opt && \
         cd /opt/Vimba_5_0/VimbaGigETL && \
         sudo ./Install.sh && \
-        sudo echo 'export GENICAM_GENTL32_PATH=$GENICAM_GENTL32_PATH:"/opt/Vimba_5_0/VimbaGigETL/CTI/x86_32bit/"' >> /home/carma/.base-image/init-env.sh && \
-        sudo echo 'export GENICAM_GENTL64_PATH=$GENICAM_GENTL64_PATH:"/opt/Vimba_5_0/VimbaGigETL/CTI/x86_64bit/"' >> /home/carma/.base-image/init-env.sh && \
         rm ~/Vimba_v5.0_Linux.tgz
 
 # Set environment variable for SonarQube Binaries. Two binaries will go in this directory:
@@ -258,12 +250,6 @@ RUN cd $SONAR_DIR && \
         # FIXME: The following symlink will no longer be required once images
         # that depend on carma-base change from wait-for-it.sh to wait-for-it
         sudo ln -s /usr/bin/wait-for-it /usr/bin/wait-for-it.sh && \
-        # Add scanner and wrapper to PATH
-        sudo echo 'export PATH=$PATH:$SONAR_DIR/sonar-scanner/bin/:$SONAR_DIR/build-wrapper/' >> /home/carma/.base-image/init-env.sh
-
-# Install gcovr for code coverage tests and add code_coverage script folder to path
-RUN sudo apt-get -y install gcovr && \
-        sudo echo 'export PATH=$PATH:/home/carma/.ci-image/engineering_tools/code_coverage/' >> /home/carma/.base-image/init-env.sh
 
 # Add engineering tools scripts to image
 ADD --chown=carma ./code_coverage /home/carma/.ci-image/engineering_tools/code_coverage
@@ -284,11 +270,6 @@ RUN sudo apt-get install --yes ${AUTOWAREAUTO_DEPS}
 
 # Install Novatel OEM7 Driver Wrapper Dependency
 RUN sudo apt-get install -y ros-foxy-gps-msgs
-
-# Add CUDA path
-RUN echo 'export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64' >> ~/.bashrc     \ 
-    && echo 'export PATH=$PATH:/usr/local/cuda/bin' >> ~/.bashrc \
-    && echo 'export CUDA_BIN_PATH=/usr/local/cuda' >> ~/.bashrc
 
 # Install pip futures to support rosbridge
 RUN pip3 install future

--- a/init-env.sh
+++ b/init-env.sh
@@ -19,6 +19,27 @@
 
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib/
 
+# Export QT X11 Forwarding variables
+export QT_X11_NO_MITSHM=1
+
+# Set Cyclone DDS as default RMW implementation
+export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+
+# Add scanner and wrapper to PATH
+export PATH=$PATH:/opt/sonarqube/sonar-scanner/bin/:/opt/sonarqube/build-wrapper/
+
+# Add code_coverage script folder to path for gcovr
+export PATH=$PATH:/home/carma/.ci-image/engineering_tools/code_coverage/
+
+# Add CUDA paths
+export CUDA_BIN_PATH=/usr/local/cuda
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64
+export PATH=$PATH:/usr/local/cuda/bin
+
+# Vimba
+export GENICAM_GENTL32_PATH=$GENICAM_GENTL32_PATH:"/opt/Vimba_5_0/VimbaGigETL/CTI/x86_32bit/"
+export GENICAM_GENTL64_PATH=$GENICAM_GENTL64_PATH:"/opt/Vimba_5_0/VimbaGigETL/CTI/x86_64bit/"
+
 [ -f "/opt/ros/noetic/setup.bash" ] && source /opt/ros/noetic/setup.bash
 [ -f "/opt/autoware.ai/ros/install/setup.bash" ] && source /opt/autoware.ai/ros/install/setup.bash
 [ -f "/opt/carma/install/setup.bash" ] && source /opt/carma/install/setup.bash


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Move export commands to init-env.sh instead of echoing exports to init-env.sh at build time
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
