### PR TITLE
init-env: restructure source existence logic to return 0 instead of 1

### DIFF
--- a/init-env.sh
+++ b/init-env.sh
@@ -40,7 +40,19 @@ export PATH=$PATH:/usr/local/cuda/bin
 export GENICAM_GENTL32_PATH=$GENICAM_GENTL32_PATH:"/opt/Vimba_5_0/VimbaGigETL/CTI/x86_32bit/"
 export GENICAM_GENTL64_PATH=$GENICAM_GENTL64_PATH:"/opt/Vimba_5_0/VimbaGigETL/CTI/x86_64bit/"
 
-[ -f "/opt/ros/noetic/setup.bash" ] && source /opt/ros/noetic/setup.bash
-[ -f "/opt/autoware.ai/ros/install/setup.bash" ] && source /opt/autoware.ai/ros/install/setup.bash
-[ -f "/opt/carma/install/setup.bash" ] && source /opt/carma/install/setup.bash
-[ -f "/opt/carma/vehicle/config/carma.env" ] && source /opt/carma/vehicle/config/carma.env # Always source environment variables as last step
+if [ -f "/opt/ros/noetic/setup.bash" ]; then
+    source /opt/ros/noetic/setup.bash
+fi
+
+if [ -f "/opt/autoware.ai/ros/install/setup.bash" ]; then
+    source /opt/autoware.ai/ros/install/setup.bash
+fi
+
+if [ -f "/opt/carma/install/setup.bash" ]; then
+    source /opt/carma/install/setup.bash
+fi
+
+# Always source environment variables as last step
+if [ -f "/opt/carma/vehicle/config/carma.env" ]; then
+    source /opt/carma/vehicle/config/carma.env
+fi


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

`[ -f file ] && command` returns 1, breaking some of our CI. Instead, return 0 if files are not found and sourced.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
