### PR TITLE
collect_gcovr.bash: revert conditional gcov logic

### DIFF
--- a/code_coverage/collect_gcovr.bash
+++ b/code_coverage/collect_gcovr.bash
@@ -54,9 +54,7 @@ find "${output_dir}" -iname "*\.gcda" -o -iname "*\.gcna" -o -iname "*\.gcov" -t
 # Grab resulting gcov files and move them to the ${output_dir} directory
 echo "Moving new files"
 cd "${output_dir}"
-if find /opt/carma -iname "*\.gcda" -o -iname "\.gcna" | grep --silent .; then
-	find /opt/carma -print0 -iname "*\.gcda" -o -iname "\.gcna" | xargs gcov
-fi
+find /opt/carma -iname "*\.gcda" -o -iname "\.gcna" | xargs gcov
 
 echo "Generating coverage.xml"
 gcovr --sonarqube coverage.xml -k -r . # Run gcovr with -k to ensure generated .gcov files are preserved -r . makes it run in the current directory


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
This PR is to revert back the changes on the coverage scripts which broke the sonar scanner analysis
## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
