### PR TITLE
Add Microsoft GSL support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,7 +86,8 @@ ARG BASE_DEPS="ca-certificates \
         openssl \
         python3-rosinstall \
         ros-noetic-desktop-full \
-        xterm"
+        xterm \
+	libmsgsl-dev"
 
 ARG ROS_DEPS="apt-transport-https \
         apt-utils \


### PR DESCRIPTION
# PR Details
## Description

This PR adds the GSL library to the apt package list so that it can be used by CARMA software that builds using the `carma-base` Docker image.

## Related GitHub Issue

Closes #181
Relates to usdot-fhwa-stol/carma-platform#2137

## Related Jira Key

CDAR-251

## Motivation and Context

Some CARMA packages depend on the GSL library.

## How Has This Been Tested?

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] New feature (non-breaking change that adds functionality)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
