### PR TITLE
Arc 161 autoware auto deps

### DIFF
--- a/humble/additional_packages.txt
+++ b/humble/additional_packages.txt
@@ -4,6 +4,7 @@ gcovr
 git
 jq
 libboost-python-dev
+libcgal-dev
 libfftw3-dev
 libgeographic-dev
 libgmock-dev
@@ -11,6 +12,7 @@ libnl-genl-3-dev
 libopenblas-dev
 libpcap-dev
 libpugixml-dev
+libxmlrpcpp-dev
 lttng-tools
 mesa-utils
 nano

--- a/humble/ros_packages.txt
+++ b/humble/ros_packages.txt
@@ -1,4 +1,5 @@
 python3-colcon-common-extensions
+ros-humble-asio-cmake-module
 ros-humble-desktop
 ros-humble-rmw-cyclonedds-cpp
 ros-humble-pcl-ros
@@ -13,6 +14,10 @@ ros-humble-automotive-platform-msgs
 ros-humble-diagnostic-updater
 ros-humble-gps-msgs
 ros-humble-joy-linux
+ros-humble-lanelet2-core
+ros-humble-lanelet2-io
+ros-humble-lanelet2-projection
+ros-humble-lanelet2-routing
 ros-humble-lgsvl-msgs
 ros-humble-osqp-vendor
 ros-humble-osrf-testing-tools-cpp

--- a/humble/ros_packages.txt
+++ b/humble/ros_packages.txt
@@ -14,10 +14,6 @@ ros-humble-automotive-platform-msgs
 ros-humble-diagnostic-updater
 ros-humble-gps-msgs
 ros-humble-joy-linux
-ros-humble-lanelet2-core
-ros-humble-lanelet2-io
-ros-humble-lanelet2-projection
-ros-humble-lanelet2-routing
 ros-humble-lgsvl-msgs
 ros-humble-osqp-vendor
 ros-humble-osrf-testing-tools-cpp


### PR DESCRIPTION
# PR Details
## Description

This PR adds dependencies needed to build autoware.auto in ROS2 Humble.

Related PR: https://github.com/usdot-fhwa-stol/autoware.auto/pull/29
## Related GitHub Issue

NA

## Related Jira Key

[ARC-161](https://usdot-carma.atlassian.net/browse/ARC-161)

## Motivation and Context

Needed as part of the ROS2 Foxy -> Humble migration

## How Has This Been Tested?

Confirmed that autoware.auto can build locally with the above packages installed.

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


[ARC-161]: https://usdot-carma.atlassian.net/browse/ARC-161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ