### PR TITLE
remove wait-for-it.sh dependence

### DIFF
--- a/noetic-foxy/Dockerfile
+++ b/noetic-foxy/Dockerfile
@@ -237,9 +237,6 @@ RUN sed -i 's|http://archive.ubuntu.com|http://us.archive.ubuntu.com|g' /etc/apt
         # Rename files
         mv "$SONAR_DIR"/sonar-scanner-* "$SONAR_DIR"/sonar-scanner/ && \
         mv "$SONAR_DIR"/build-wrapper-* "$SONAR_DIR"/build-wrapper/ && \
-        # FIXME: The following symlink will no longer be required once images
-        # that depend on carma-base change from wait-for-it.sh to wait-for-it
-        ln -s /usr/bin/wait-for-it /usr/bin/wait-for-it.sh && \
         # Install non-ros1 dependant version of catkin
         # This can be used without issue for ROS2 builds wheras the noetic version has compatability issues
         # install catkin_pkg


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Removing this symlink because it is not needed.
<!--- Describe your changes in detail -->

## Related GitHub Issue
NA
<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
NA
<!-- e.g. CAR-123 -->

## Motivation and Context
Upgrade to ROS2 Humble, thought I might fix this.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
This works on humble image without it
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
