### PR TITLE
remove dependence of wait-for-it-sh symlink noetic

### DIFF
--- a/noetic/Dockerfile
+++ b/noetic/Dockerfile
@@ -108,8 +108,7 @@ COPY --chown=carma ./entrypoint.sh ${DOCKERFILE_DIR}/init-env.sh /home/carma/.ba
 COPY --chown=carma ./code_coverage /home/carma/.ci-image/engineering_tools/code_coverage
 
 # Step 13: Set up ROS environment
-RUN ln -s /usr/bin/wait-for-it /usr/bin/wait-for-it.sh && \
-    rosdep --rosdistro noetic init && \
+RUN rosdep --rosdistro noetic init && \
     sudo -u carma rosdep --rosdistro noetic update && \
     sudo -u carma rosdep --rosdistro noetic install --from-paths /home/carma/.base-image/workspace/src --ignore-src -y && \
     sudo -u carma echo "source ~/.base-image/init-env.sh" >> /home/carma/.bashrc && \


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Removing `wait-for-it.sh` symlink to `wait-for-it` because it is not needed.
<!--- Describe your changes in detail -->

## Related GitHub Issue
NA
<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
NA
<!-- e.g. CAR-123 -->

## Motivation and Context
Upgrade to ROS2 Humble, thought I might fix this.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Tested this on previous 4.5.0 image by removing the symlink the package itself works fine directly
![image](https://github.com/user-attachments/assets/241324c0-356b-432a-8442-045c6b021a8a)


<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
