### PR TITLE
added PROJ cmake as part of docker file build

### DIFF
--- a/humble/Dockerfile
+++ b/humble/Dockerfile
@@ -37,6 +37,9 @@ RUN apt-get update && \
 RUN apt-get update && \
     apt-get install -y $(cat /tmp/additional_packages.txt)
 
+# Set up PROJ
+RUN curl -o /usr/share/cmake-3.22/Modules/FindPROJ.cmake https://raw.githubusercontent.com/OSGeo/libgeotiff/refs/heads/master/libgeotiff/cmake/FindPROJ.cmake
+
 # Install Python packages
 RUN apt-get update && apt-get install -y python3-pip
 RUN pip3 install --no-cache-dir vcstool setuptools pybind11


### PR DESCRIPTION
# PR Details
## Description

This PR adds a step to the humble Dockerfile base image.

## Related GitHub Issue

NA

## Related Jira Key

[ARC-160](https://usdot-carma.atlassian.net/browse/ARC-160)

## Motivation and Context

This change is needed for the `lanelet_extensions` package in `autoware.ai` to build in ROS 2 Humble.

Related PR for porting autoware.ai to Humble: [autoware.ai#275](https://github.com/usdot-fhwa-stol/autoware.ai/pull/275)

## How Has This Been Tested?

Confirmed that all of autoware.ai builds when using this base image.

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


[ARC-160]: https://usdot-carma.atlassian.net/browse/ARC-160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ